### PR TITLE
Updates to work with the chrome headless branch of prerender server.

### DIFF
--- a/lib/file-system-cache.js
+++ b/lib/file-system-cache.js
@@ -9,7 +9,7 @@ module.exports = {
     });
   },
 
-  beforePhantomRequest: function(req, res, next) {
+  requestReceived: function(req, res, next) {
     if (req.method !== 'GET') {
       return next();
     }
@@ -21,7 +21,9 @@ module.exports = {
       if (!err && result) {
         console.info('cache hit for: '+req.prerender.url);
         req.prerender.fileSystemCached = true;
+        req.prerender.responseSent = true;
         res.send(200, result);
+        return next();
       }
       else {
         return next();
@@ -29,12 +31,12 @@ module.exports = {
     });
   },
 
-  afterPhantomRequest: function(req, res, next) {
+  pageLoaded: function(req, res, next) {
     if (!req.prerender.fileSystemCached) {
       /*
       * we are only getting here if the cache was not there
       */
-      this.cache.set(req.prerender.url, req.prerender.documentHTML);
+      this.cache.set(req.prerender.url, req.prerender.content);
     }
     next();
   }


### PR DESCRIPTION
Just a couple of changes to hook into the events used by the updated branch of prerender.io to work with chrome headless instead of phantomJS based events.